### PR TITLE
Configure In-App Purchases for Apple Pay

### DIFF
--- a/WildSparks.xcodeproj/project.pbxproj
+++ b/WildSparks.xcodeproj/project.pbxproj
@@ -203,6 +203,14 @@
 				TargetAttributes = {
 					F045AA832D7DE2B8009DECE1 = {
 						CreatedOnToolsVersion = 16.3;
+						SystemCapabilities = {
+							com.apple.InAppPurchase = {
+								enabled = 1;
+							};
+							com.apple.StoreKit = {
+								enabled = 1;
+							};
+						};
 					};
 					F045AA912D7DE2BA009DECE1 = {
 						CreatedOnToolsVersion = 16.3;

--- a/WildSparks/WildSparks.entitlements
+++ b/WildSparks/WildSparks.entitlements
@@ -22,5 +22,7 @@
 	<true/>
 	<key>com.apple.security.files.user-selected.read-only</key>
 	<true/>
+	<key>com.apple.developer.in-app-payments</key>
+	<array/>
 </dict>
 </plist>


### PR DESCRIPTION
This commit ensures the project is properly configured for In-App Purchases, which are processed via Apple Pay by default when available through StoreKit.

Key changes:
- Enabled the "In-App Purchase" capability in Xcode project settings.
- Added the `com.apple.developer.in-app-payments` key to the `WildSparks.entitlements` file.

The existing StoreKit implementation in `PaywallView.swift` and `StoreManager.swift` already utilizes modern APIs that support Apple Pay without requiring specific code changes for Apple Pay itself. The focus is on correct project configuration and App Store Connect setup to enable real transactions.