### PR TITLE
Refactor login and onboarding flow

### DIFF
--- a/WildSparks/LoadingView.swift
+++ b/WildSparks/LoadingView.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+struct LoadingView: View {
+    var body: some View {
+        VStack {
+            Spacer()
+            HStack {
+                Spacer()
+                ProgressView()
+                Spacer()
+            }
+            Spacer()
+        }
+    }
+}

--- a/WildSparks/OnboardingView.swift
+++ b/WildSparks/OnboardingView.swift
@@ -6,11 +6,11 @@ struct OnboardingView: View {
     @EnvironmentObject var userProfile: UserProfile // Add this
     @EnvironmentObject var locationManager: LocationManager // Add this
     @EnvironmentObject var storeManager: StoreManager // Add this
-    @State private var isSignedIn = false
-    @State private var isNewUser = false
+    // isSignedIn and isNewUser are removed as initial routing is handled by WildSparksApp
     @State private var navigateToHome = false
     @State private var navigateToOnboardingForm = false
     
+    // OnboardingView now manages its own SignInWithAppleManager instance for the button action.
     private let signInWithAppleManager = SignInWithAppleManager()
     
     var body: some View {
@@ -33,32 +33,36 @@ struct OnboardingView: View {
                         .multilineTextAlignment(.center)
                         .padding(.horizontal, 20)
                     
-                    if !isSignedIn {
-                        SignInWithAppleButton(
-                            .signIn,
-                            onRequest: { request in
-                                request.requestedScopes = [.fullName, .email]
-                            },
-                            onCompletion: { result in
-                                switch result {
-                                case .success(let authorization):
-                                    signInWithAppleManager.handleAuthorization(authorization) { success in
-                                        if success {
-                                            checkForExistingProfile()
-                                        }
+                    // The SignInWithAppleButton is now always visible when OnboardingView is shown.
+                    SignInWithAppleButton(
+                        .signIn,
+                        onRequest: { request in
+                            request.requestedScopes = [.fullName, .email]
+                        },
+                        onCompletion: { result in
+                            switch result {
+                            case .success(let authorization):
+                                // Use the local signInWithAppleManager
+                                signInWithAppleManager.handleAuthorization(authorization) { success in
+                                    if success {
+                                        // Call the local checkForExistingProfile
+                                        checkForExistingProfile()
+                                    } else {
+                                        // Handle authorization failure if needed, e.g., show an alert
+                                        print("OnboardingView: Sign in with Apple authorization failed.")
                                     }
-                                case .failure(let error):
-                                    print("Sign in with Apple failed: \(error.localizedDescription)")
                                 }
+                            case .failure(let error):
+                                print("OnboardingView: Sign in with Apple failed: \(error.localizedDescription)")
                             }
-                        )
-                        .frame(height: 50)
-                        .frame(maxWidth: 300)
-                        .signInWithAppleButtonStyle(.black)
-                        .cornerRadius(10)
-                        .padding(.top, 10)
-                        .shadow(radius: 3)
-                    }
+                        }
+                    )
+                    .frame(height: 50)
+                    .frame(maxWidth: 300)
+                    .signInWithAppleButtonStyle(.black)
+                    .cornerRadius(10)
+                    .padding(.top, 10)
+                    .shadow(radius: 3)
                     
                     Spacer()
                     
@@ -82,24 +86,7 @@ struct OnboardingView: View {
                     .padding(.bottom, 30)
                 }
             }
-            .onAppear {
-                // Directly navigate to OnboardingForm if userIdentifier is missing
-                if UserDefaults.standard.string(forKey: "appleUserIdentifier") == nil {
-                    print("OnboardingView: No appleUserIdentifier found, navigating to OnboardingForm.")
-                    self.navigateToOnboardingForm = true
-                    self.isSignedIn = false // Ensure UI consistency
-                    return // Prevent other checks
-                }
-
-                signInWithAppleManager.restorePreviousSignIn { isNew in
-                    self.isNewUser = isNew
-                    self.isSignedIn = !isNew
-                    
-                    if self.isSignedIn {
-                        checkForExistingProfile()
-                    }
-                }
-            }
+            // .onAppear logic is removed as WildSparksApp now handles initial view determination.
             .navigationDestination(isPresented: $navigateToHome) {
                 ContentView()
                     .environmentObject(userProfile) // Pass environment objects
@@ -112,31 +99,48 @@ struct OnboardingView: View {
                     .environmentObject(locationManager)
                     .environmentObject(storeManager)
             }
-            .animation(.easeInOut, value: isSignedIn)
+            // animation value changed from isSignedIn (removed) to navigateToHome and navigateToOnboardingForm
+            .animation(.easeInOut, value: navigateToHome)
+            .animation(.easeInOut, value: navigateToOnboardingForm)
         }
     }
     
+    // This function is kept locally for the button action to decide navigation after sign-in.
     private func checkForExistingProfile() {
         guard let userIdentifier = UserDefaults.standard.string(forKey: "appleUserIdentifier") else {
-            print("No userIdentifier found")
+            print("OnboardingView: No userIdentifier found after sign-in attempt.")
+            // Optionally, handle this case, e.g., show an error or default to onboarding form
+            self.navigateToOnboardingForm = true 
             return
         }
         
         let recordID = CKRecord.ID(recordName: "\(userIdentifier)_profile")
         CKContainer.default().publicCloudDatabase.fetch(withRecordID: recordID) { record, error in
-            if let error = error as? CKError, error.code == .unknownItem {
-                print("No existing profile found — redirecting to onboarding")
-                self.navigateToOnboardingForm = true
-            } else if record != nil {
-                print("Existing profile found — redirecting to home")
-                self.navigateToHome = true
-            } else if let error = error {
-                print("Error checking profile: \(error.localizedDescription)")
+            DispatchQueue.main.async { // Ensure UI updates are on the main thread
+                if let error = error as? CKError, error.code == .unknownItem {
+                    print("OnboardingView: No existing profile found — redirecting to onboarding form.")
+                    self.navigateToOnboardingForm = true
+                } else if record != nil {
+                    print("OnboardingView: Existing profile found — redirecting to home.")
+                    self.navigateToHome = true
+                } else if let error = error {
+                    print("OnboardingView: Error checking profile: \(error.localizedDescription). Defaulting to onboarding form.")
+                    // Fallback decision, could be an alert or specific error view
+                    self.navigateToOnboardingForm = true 
+                } else {
+                    // Should not happen (no record, no error)
+                    print("OnboardingView: Unexpected state in checkForExistingProfile. Defaulting to onboarding form.")
+                    self.navigateToOnboardingForm = true
+                }
             }
         }
     }
 }
 
+// SignInWithAppleManager remains defined locally in OnboardingView
+// as it's directly used by the SignInWithAppleButton in this view.
+// Its restorePreviousSignIn method is no longer called by OnboardingView's .onAppear,
+// but handleAuthorization is crucial for the button's action.
 class SignInWithAppleManager: NSObject, ASAuthorizationControllerDelegate {
     func handleAuthorization(_ authorization: ASAuthorization, completion: @escaping (Bool) -> Void) {
         if let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential {
@@ -144,48 +148,79 @@ class SignInWithAppleManager: NSObject, ASAuthorizationControllerDelegate {
             let fullName = appleIDCredential.fullName
             let email = appleIDCredential.email
             
-            print("User ID: \(userIdentifier)")
-            print("Full Name: \(fullName?.givenName ?? "") \(fullName?.familyName ?? "")")
-            print("Email: \(email ?? "")")
+            print("OnboardingView.SignInManager: User ID: \(userIdentifier)")
+            if let given = fullName?.givenName, let family = fullName?.familyName {
+                print("OnboardingView.SignInManager: Full Name: \(given) \(family)")
+            }
+            if let mail = email {
+                print("OnboardingView.SignInManager: Email: \(mail)")
+            }
             
             UserDefaults.standard.set(userIdentifier, forKey: "appleUserIdentifier")
             
-            let recordID = CKRecord.ID(recordName: userIdentifier)
-            let record = CKRecord(recordType: "User", recordID: recordID)
-            record["fullName"] = "\(fullName?.givenName ?? "") \(fullName?.familyName ?? "")" as NSString
-            record["email"] = email as NSString?
+            // CloudKit saving logic might be redundant if WildSparksApp handles user creation/update upon sign-in.
+            // However, for now, keeping it to ensure user record is created/updated.
+            // This could be a point of future refactoring to centralize User record creation.
+            let recordID = CKRecord.ID(recordName: userIdentifier) // Using just userIdentifier for "User" record for simplicity, profile is separate
+            let userRecord = CKRecord(recordType: "User", recordID: recordID) // Changed to "User" record type
             
-            CKContainer.default().publicCloudDatabase.save(record) { _, error in
-                if let error = error {
-                    print("Error saving to CloudKit: \(error.localizedDescription)")
-                    completion(false)
-                } else {
-                    print("User saved to CloudKit")
-                    completion(true)
+            var nameToSave = ""
+            if let givenName = fullName?.givenName, !givenName.isEmpty {
+                nameToSave += givenName
+            }
+            if let familyName = fullName?.familyName, !familyName.isEmpty {
+                nameToSave += (nameToSave.isEmpty ? "" : " ") + familyName
+            }
+            
+            if !nameToSave.isEmpty {
+                userRecord["fullName"] = nameToSave as CKRecordValue
+            }
+            if let email = email, !email.isEmpty {
+                userRecord["email"] = email as CKRecordValue
+            }
+            
+            CKContainer.default().publicCloudDatabase.save(userRecord) { _, error in
+                DispatchQueue.main.async {
+                    if let error = error {
+                        print("OnboardingView.SignInManager: Error saving user to CloudKit: \(error.localizedDescription)")
+                        completion(false)
+                    } else {
+                        print("OnboardingView.SignInManager: User saved to CloudKit")
+                        completion(true)
+                    }
                 }
             }
         } else {
-            completion(false)
+            DispatchQueue.main.async {
+                completion(false)
+            }
         }
     }
     
+    // restorePreviousSignIn is kept in case it's needed for other purposes within this manager,
+    // but it's not used by OnboardingView's .onAppear anymore.
     func restorePreviousSignIn(completion: @escaping (Bool) -> Void) {
         if let userIdentifier = UserDefaults.standard.string(forKey: "appleUserIdentifier") {
             let provider = ASAuthorizationAppleIDProvider()
             provider.getCredentialState(forUserID: userIdentifier) { state, _ in
-                switch state {
-                case .authorized:
-                    print("User is still authorized")
-                    completion(false)
-                case .revoked, .notFound:
-                    print("User is not signed in")
-                    completion(true)
-                default:
-                    completion(true)
+                DispatchQueue.main.async {
+                    switch state {
+                    case .authorized:
+                        print("OnboardingView.SignInManager: User is still authorized (checked by local manager)")
+                        completion(false) 
+                    case .revoked, .notFound:
+                        print("OnboardingView.SignInManager: User is revoked or not found (checked by local manager)")
+                        completion(true) 
+                    default:
+                        print("OnboardingView.SignInManager: Unknown credential state (checked by local manager)")
+                        completion(true)
+                    }
                 }
             }
         } else {
-            completion(true)
+            DispatchQueue.main.async {
+                completion(true)
+            }
         }
     }
 }


### PR DESCRIPTION
- Introduced a LoadingView to prevent OnboardingView flicker for logged-in users.
- Centralized initial view routing logic in WildSparksApp.swift to determine whether to show LoadingView, OnboardingView, OnboardingForm, or ContentView based on authentication status and profile existence.
- Simplified OnboardingView to primarily handle the 'Sign in with Apple' action and subsequent navigation.
- Ensured new users are consistently directed to OnboardingFormView if no profile exists after sign-in.
- Ensured existing users who are logged out are correctly navigated to ContentView after re-signing in.