### PR TITLE
feat: Optimize image memory usage

### DIFF
--- a/WildSparks/UIImage+Resize.swift
+++ b/WildSparks/UIImage+Resize.swift
@@ -1,0 +1,24 @@
+import UIKit
+import ImageIO
+
+extension UIImage {
+    static func resizeImage(data: Data, to targetSize: CGSize) -> UIImage? {
+        let options: [CFString: Any] = [
+            kCGImageSourceShouldCache: false,
+            kCGImageSourceCreateThumbnailFromImageIfAbsent: true,
+            kCGImageSourceThumbnailMaxPixelSize: max(targetSize.width, targetSize.height)
+        ]
+
+        guard let imageSource = CGImageSourceCreateWithData(data as CFData, options as CFDictionary) else {
+            print("Error: Could not create image source.")
+            return nil
+        }
+
+        guard let cgImage = CGImageSourceCreateThumbnailAtIndex(imageSource, 0, options as CFDictionary) else {
+            print("Error: Could not create thumbnail from image source.")
+            return nil
+        }
+
+        return UIImage(cgImage: cgImage)
+    }
+}


### PR DESCRIPTION
Implemented image downsampling and caching to reduce memory consumption.

- Added a `UIImage` extension to resize images efficiently using Core Graphics.
- Modified `HomeView` to:
  - Downsample profile and gallery images for `NearbyUser` objects before storing them in memory.
  - Implement an `NSCache` to store and retrieve downsampled images, reducing redundant loading and processing.
- Modified `ProfileView` to:
  - Downsample your own profile images on load.
  - Resize newly selected photos before storing them.
  - Changed the underlying storage for profile photos from `[Data]` to `[UIImage]`.

These changes aim to prevent crashes due to excessive memory usage by ensuring that images are not held in memory at their full resolution unnecessarily.