### PR TITLE
Fix concurrency annotations

### DIFF
--- a/WildSparks/BroadcastView.swift
+++ b/WildSparks/BroadcastView.swift
@@ -895,6 +895,7 @@ extension BroadcastView {
                 }
             }
         }
+        }
         
         func containsBannedWord(message: String) -> Bool {
             let messageLowercased = message.lowercased()
@@ -936,7 +937,6 @@ extension BroadcastView {
 }
 
 // Close the BroadcastView extension
-}
 
 
 // MARK: - Broadcast View

--- a/WildSparks/BroadcastView.swift
+++ b/WildSparks/BroadcastView.swift
@@ -913,13 +913,14 @@ extension BroadcastView {
             rec["ethnicity"] = "Other" as NSString
             rec["radius"] = NSNumber(value: maxRadiusSubscribed)
 
+            let schedule = self.mainAsyncAfter
             database.save(rec) { [weak self] (savedRecord: CKRecord?, error: Error?) in
                 guard let self = self else { return }
                 if let error {
                     print("Error simulating broadcast: \(error.localizedDescription)")
                 } else {
                     print("Simulated broadcast saved.")
-                    self.mainAsyncAfter(1.0) { [weak self] in
+                    schedule(1.0) { [weak self] in
                         guard let self = self else { return }
                         Task { @MainActor in
                             self.loadNearbyBroadcasts()

--- a/WildSparks/BroadcastView.swift
+++ b/WildSparks/BroadcastView.swift
@@ -934,6 +934,9 @@ extension BroadcastView {
     }
 }
 
+// Close the BroadcastView extension
+}
+
 
 // MARK: - Broadcast View
 struct BroadcastView: View {

--- a/WildSparks/CloudKitProtocols.swift
+++ b/WildSparks/CloudKitProtocols.swift
@@ -2,10 +2,23 @@ import CloudKit
 
 // Protocol for CKDatabase to allow mocking and improve testability
 protocol CKDatabaseProtocol {
-    func save(_ record: CKRecord, completionHandler: @escaping (CKRecord?, Error?) -> Void)
-    func delete(withRecordID recordID: CKRecord.ID, completionHandler: @escaping (CKRecord.ID?, Error?) -> Void)
-    func perform(_ query: CKQuery, inZoneWith zoneID: CKRecordZone.ID?, completionHandler: @escaping ([CKRecord]?, Error?) -> Void)
-    func fetch(withRecordID recordID: CKRecord.ID, completionHandler: @escaping (CKRecord?, Error?) -> Void)
+    func save(
+        _ record: CKRecord,
+        completionHandler: @escaping @Sendable (CKRecord?, Error?) -> Void
+    )
+    func delete(
+        withRecordID recordID: CKRecord.ID,
+        completionHandler: @escaping @Sendable (CKRecord.ID?, Error?) -> Void
+    )
+    func perform(
+        _ query: CKQuery,
+        inZoneWith zoneID: CKRecordZone.ID?,
+        completionHandler: @escaping @Sendable ([CKRecord]?, Error?) -> Void
+    )
+    func fetch(
+        withRecordID recordID: CKRecord.ID,
+        completionHandler: @escaping @Sendable (CKRecord?, Error?) -> Void
+    )
     // Add other CKDatabase methods used by your app if they become necessary for the protocol
 }
 

--- a/WildSparks/CloudKitProtocols.swift
+++ b/WildSparks/CloudKitProtocols.swift
@@ -2,10 +2,10 @@ import CloudKit
 
 // Protocol for CKDatabase to allow mocking and improve testability
 protocol CKDatabaseProtocol {
-    func save(_ record: CKRecord, completionHandler: @Sendable @escaping (CKRecord?, Error?) -> Void)
-    func delete(withRecordID recordID: CKRecord.ID, completionHandler: @Sendable @escaping (CKRecord.ID?, Error?) -> Void)
-    func perform(_ query: CKQuery, inZoneWith zoneID: CKRecordZone.ID?, completionHandler: @Sendable @escaping ([CKRecord]?, Error?) -> Void)
-    func fetch(withRecordID recordID: CKRecord.ID, completionHandler: @Sendable @escaping (CKRecord?, Error?) -> Void)
+    func save(_ record: CKRecord, completionHandler: @escaping (CKRecord?, Error?) -> Void)
+    func delete(withRecordID recordID: CKRecord.ID, completionHandler: @escaping (CKRecord.ID?, Error?) -> Void)
+    func perform(_ query: CKQuery, inZoneWith zoneID: CKRecordZone.ID?, completionHandler: @escaping ([CKRecord]?, Error?) -> Void)
+    func fetch(withRecordID recordID: CKRecord.ID, completionHandler: @escaping (CKRecord?, Error?) -> Void)
     // Add other CKDatabase methods used by your app if they become necessary for the protocol
 }
 

--- a/WildSparks/CloudKitProtocols.swift
+++ b/WildSparks/CloudKitProtocols.swift
@@ -2,10 +2,10 @@ import CloudKit
 
 // Protocol for CKDatabase to allow mocking and improve testability
 protocol CKDatabaseProtocol {
-    func save(_ record: CKRecord, completionHandler: @escaping (CKRecord?, Error?) -> Void)
-    func delete(withRecordID recordID: CKRecord.ID, completionHandler: @escaping (CKRecord.ID?, Error?) -> Void)
-    func perform(_ query: CKQuery, inZoneWith zoneID: CKRecordZone.ID?, completionHandler: @escaping ([CKRecord]?, Error?) -> Void)
-    func fetch(withRecordID recordID: CKRecord.ID, completionHandler: @escaping (CKRecord?, Error?) -> Void)
+    func save(_ record: CKRecord, completionHandler: @escaping @Sendable (CKRecord?, Error?) -> Void)
+    func delete(withRecordID recordID: CKRecord.ID, completionHandler: @escaping @Sendable (CKRecord.ID?, Error?) -> Void)
+    func perform(_ query: CKQuery, inZoneWith zoneID: CKRecordZone.ID?, completionHandler: @escaping @Sendable ([CKRecord]?, Error?) -> Void)
+    func fetch(withRecordID recordID: CKRecord.ID, completionHandler: @escaping @Sendable (CKRecord?, Error?) -> Void)
     // Add other CKDatabase methods used by your app if they become necessary for the protocol
 }
 

--- a/WildSparks/CloudKitProtocols.swift
+++ b/WildSparks/CloudKitProtocols.swift
@@ -2,10 +2,10 @@ import CloudKit
 
 // Protocol for CKDatabase to allow mocking and improve testability
 protocol CKDatabaseProtocol {
-    func save(_ record: CKRecord, completionHandler: @escaping @Sendable (CKRecord?, Error?) -> Void)
-    func delete(withRecordID recordID: CKRecord.ID, completionHandler: @escaping @Sendable (CKRecord.ID?, Error?) -> Void)
-    func perform(_ query: CKQuery, inZoneWith zoneID: CKRecordZone.ID?, completionHandler: @escaping @Sendable ([CKRecord]?, Error?) -> Void)
-    func fetch(withRecordID recordID: CKRecord.ID, completionHandler: @escaping @Sendable (CKRecord?, Error?) -> Void)
+    func save(_ record: CKRecord, completionHandler: @escaping (CKRecord?, Error?) -> Void)
+    func delete(withRecordID recordID: CKRecord.ID, completionHandler: @escaping (CKRecord.ID?, Error?) -> Void)
+    func perform(_ query: CKQuery, inZoneWith zoneID: CKRecordZone.ID?, completionHandler: @escaping ([CKRecord]?, Error?) -> Void)
+    func fetch(withRecordID recordID: CKRecord.ID, completionHandler: @escaping (CKRecord?, Error?) -> Void)
     // Add other CKDatabase methods used by your app if they become necessary for the protocol
 }
 

--- a/WildSparks/CloudKitProtocols.swift
+++ b/WildSparks/CloudKitProtocols.swift
@@ -2,10 +2,10 @@ import CloudKit
 
 // Protocol for CKDatabase to allow mocking and improve testability
 protocol CKDatabaseProtocol {
-    func save(_ record: CKRecord, completionHandler: @escaping (CKRecord?, Error?) -> Void)
-    func delete(withRecordID recordID: CKRecord.ID, completionHandler: @escaping (CKRecord.ID?, Error?) -> Void)
-    func perform(_ query: CKQuery, inZoneWith zoneID: CKRecordZone.ID?, completionHandler: @escaping ([CKRecord]?, Error?) -> Void)
-    func fetch(withRecordID recordID: CKRecord.ID, completionHandler: @escaping (CKRecord?, Error?) -> Void)
+    func save(_ record: CKRecord, completionHandler: @Sendable @escaping (CKRecord?, Error?) -> Void)
+    func delete(withRecordID recordID: CKRecord.ID, completionHandler: @Sendable @escaping (CKRecord.ID?, Error?) -> Void)
+    func perform(_ query: CKQuery, inZoneWith zoneID: CKRecordZone.ID?, completionHandler: @Sendable @escaping ([CKRecord]?, Error?) -> Void)
+    func fetch(withRecordID recordID: CKRecord.ID, completionHandler: @Sendable @escaping (CKRecord?, Error?) -> Void)
     // Add other CKDatabase methods used by your app if they become necessary for the protocol
 }
 


### PR DESCRIPTION
## Summary
- adjust CloudKit protocol to use `@Sendable` closures
- update deprecated `onChange` handlers
- ensure main actor access when timers and background queues mutate UI state
- mark asynchronous closure type alias as `@Sendable`

## Testing
- `xcodebuild test -project WildSparks.xcodeproj -scheme WildSparks -destination 'platform=iOS Simulator,name=iPhone 14'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843601586908322b477f3c407b2c8b3