### PR TITLE
Fix memory bloat from image loading

### DIFF
--- a/WildSparks/HomeView.swift
+++ b/WildSparks/HomeView.swift
@@ -1262,8 +1262,7 @@ struct HomeView: View {
                     var image: UIImage? = nil
                     if let asset = rec["photo1"] as? CKAsset,
                        let url = asset.fileURL,
-                       let data = try? Data(contentsOf: url),
-                       let ui = UIImage(data: data) {
+                       let ui = UIImage(contentsOfFile: url.path) {
                         image = ui
                     }
 
@@ -1271,8 +1270,7 @@ struct HomeView: View {
                     for i in 1...6 {
                         if let asset = rec["photo\(i)"] as? CKAsset,
                            let url = asset.fileURL,
-                           let data = try? Data(contentsOf: url),
-                           let uiImage = UIImage(data: data) {
+                           let uiImage = UIImage(contentsOfFile: url.path) {
                             photos.append(uiImage)
                         }
                     }

--- a/WildSparks/LikesView.swift
+++ b/WildSparks/LikesView.swift
@@ -256,8 +256,7 @@ struct LikesView: View {
                 for i in 1...6 {
                     if let asset = rec["photo\(i)"] as? CKAsset,
                        let url = asset.fileURL,
-                       let data = try? Data(contentsOf: url),
-                       let uiImage = UIImage(data: data) {
+                       let uiImage = UIImage(contentsOfFile: url.path) {
                         photos.append(uiImage)
                     }
                 }

--- a/WildSparks/MatchView.swift
+++ b/WildSparks/MatchView.swift
@@ -228,8 +228,7 @@ struct MatchesView: View {
                         var img: UIImage?
                         if let asset = rec["photo1"] as? CKAsset,
                            let url = asset.fileURL,
-                           let data = try? Data(contentsOf: url),
-                           let ui = UIImage(data: data) {
+                           let ui = UIImage(contentsOfFile: url.path) {
                             img = ui
                         }
                         loaded.append(Match(id: uid, name: name, image: img))
@@ -568,8 +567,7 @@ struct ProfileDetailView: View {
                 photos = (1...6).compactMap { i in
                     guard let asset = rec["photo\(i)"] as? CKAsset,
                           let url = asset.fileURL,
-                          let d = try? Data(contentsOf: url),
-                          let ui = UIImage(data: d) else { return nil }
+                          let ui = UIImage(contentsOfFile: url.path) else { return nil }
                     return ui
                 }
             }

--- a/WildSparks/ProfileView.swift
+++ b/WildSparks/ProfileView.swift
@@ -1045,7 +1045,7 @@ struct ProfileView: View {
                 for i in 1...6 {
                     if let a = r["photo\(i)"] as? CKAsset,
                        let url = a.fileURL,
-                       let d = try? Data(contentsOf: url) {
+                       let d = try? Data(contentsOf: url, options: .mappedIfSafe) {
                         images.append(d)
                     }
                 }


### PR DESCRIPTION
## Summary
- optimize image loading from CloudKit assets
- map temporary photo data when loading profile

## Testing
- `swift test -l` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684377d5768c8322a45889d5d017373f